### PR TITLE
Add 'slugify' config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ site configuration. If specified, archive will be generated in
 `PATH/CATEGORY/index.html`, where `PATH` is substituted by `path`, `CATEGORY` is the category
 the archive for. Default is null string.
 
+If the `slugify` key is set to `true`, then category URLs will be slugified.
+ie: the url for "My Category" will be 'categories/my-category' not
+'categories/My%20Category'
 
 # Liquid variables for template
 

--- a/_plugins/category_archive_plugin.rb
+++ b/_plugins/category_archive_plugin.rb
@@ -56,6 +56,11 @@ module Jekyll
 	      category = @category
       end
 
+
+      if context.registers[:site].config['category_archive']['slugify']
+        category = Utils.slugify(category)
+      end
+
       href = File.join('/', context.environments.first['site']['category_archive']['path'],
                        category, 'index.html')
       "<a href=\"#{href}\">#{super}</a>"
@@ -73,7 +78,13 @@ module Jekyll
       @site = site
       @dir = dir
       @category = category
-      @category_dir_name = @category # require sanitize here
+
+      if site.config['category_archive']['slugify']
+        @category_dir_name = Utils.slugify(@category) # require sanitize here
+      else 
+        @category_dir_name = @category
+      end
+
       @layout =  site.config['category_archive'] && site.config['category_archive']['layout'] || 'category_archive'
       self.ext = '.html'
       self.basename = 'index'


### PR DESCRIPTION
Adding `slugify: true` to the `category_archive` config object will slugify all urls for category archives.

ie: The archive for category "Ruby on Rails" would be 'category/ruby-on-rails/index.html' rather than 'category/Ruby%20on%20Rails/index.html'
