### PR TITLE
fixed CategoryArchiveLinkTag to include basesite in categorylinks

### DIFF
--- a/_plugins/category_archive_plugin.rb
+++ b/_plugins/category_archive_plugin.rb
@@ -61,7 +61,7 @@ module Jekyll
         category = Utils.slugify(category)
       end
 
-      href = File.join('/', context.environments.first['site']['category_archive']['path'],
+      href = File.join('/', context.registers[:site].baseurl, context.environments.first['site']['category_archive']['path'],
                        category, 'index.html')
       "<a href=\"#{href}\">#{super}</a>"
     end


### PR DESCRIPTION
Consider the a situation where:

``` yaml
url: "http://qwe.rty"
basesite: "/blog/"
category_archive:
    path: /category
```

The site thus runs at `http://qwe.rty/blog/`. In the current version of this plugin, archives are created in `.../category` (available at `http://qwe.rty/blog/category/...`), but links generated with `categorylink` point to `http://qwe.rty/category/...` and are thus broken.

The proposed change would insert the `basesite` path in the URL generated by `categorylink`. Maybe this is too hacky; I didn't spend much time looking at the code. But it seems to work.
