### PR TITLE
Update to support Jekyll 3.0

### DIFF
--- a/_plugins/category_archive_plugin.rb
+++ b/_plugins/category_archive_plugin.rb
@@ -35,7 +35,7 @@ module Jekyll
 
     def posts_group_by_category(site)
       category_map = {}
-      site.posts.each {|p| p.categories.each {|c| (category_map[c] ||= []) << p } }
+      site.posts.docs.each {|p| p["categories"].each {|c| (category_map[c] ||= []) << p } }
       category_map
     end
   end


### PR DESCRIPTION
Some updates to get rid of deprecation warning on the new Jekyll 3.0 version. Related issue https://github.com/shigeya/jekyll-category-archive-plugin/issues/15
